### PR TITLE
Fixed problems with tns file encoding

### DIFF
--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -390,7 +390,7 @@ namespace Utils
     * @return Contents of file.
     * @exception QString describing I/O problem.
     */
-    QString toReadFile(const QString &filename);
+    TORA_EXPORT QString toReadFile(const QString &filename);
 
     /** Read file from filename and return it as binary data (no decoding).
     * @param filename Filename to read file from.


### PR DESCRIPTION
In past we were reading the TNS file as a byte array for unspecified
reasons. This caused problems on windows if the file was encoded using
some special encoding, such as Unicode and caused tora to crash. Now the
file is read as a QString which automagically handles all of that and
doesn't cause crashes, while working just fine.

I also added some comments there and cleaned up parsing of garbage TNS
files as well as skipping of same database names which are used multiple
times in 1 file