### PR TITLE
Add alternate library name for Qt5 QScintella

### DIFF
--- a/cmake/modules/FindQScintilla.cmake
+++ b/cmake/modules/FindQScintilla.cmake
@@ -84,7 +84,7 @@ IF(Qt5Widgets_FOUND)
     SET(LIBRARYPATH ${QT5_WIDGETSLIBRARYPATH} "/usr/lib/" "/usr/local/lib")
     MESSAGE("QScintilla2 LIBPATH \"${LIBRARYPATH}\"")
 
-    FIND_LIBRARY(QSCINTILLA_LIBRARY NAMES qt5scintilla2 libqscintilla2.a qscintilla2.lib PATHS ${LIBRARYPATH})
+    FIND_LIBRARY(QSCINTILLA_LIBRARY NAMES qscintilla2-qt5 qt5scintilla2 libqscintilla2.a qscintilla2.lib PATHS ${LIBRARYPATH})
 
     # Check
     IF(QSCINTILLA_LIBRARY)


### PR DESCRIPTION
Under Arch Linux, the library's named libqscintilla2-qt5. Without this change, you'd need to use the internal QScintilla on Arch Linux.