### PR TITLE
Fix compile errors on Linux

### DIFF
--- a/src/editor/toworksheettext.cpp
+++ b/src/editor/toworksheettext.cpp
@@ -43,6 +43,7 @@
 
 #include <QtCore/QFileSystemWatcher>
 #include <QListWidget>
+#include <QDir>
 
 #include "core/toeditorconfiguration.h"
 


### PR DESCRIPTION
I was able to compile Tora (latest master) on latest Debian testing. However it needed another [workaround suggested in #65](https://github.com/tora-tool/tora/issues/65#issuecomment-289251655). So I executed this before running cmake:

```
export CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0"
```

Signed-off-by: Daniele Ricci <daniele.athome@gmail.com>