### PR TITLE
tora doesn't do a good job of finding qscintilla2 library installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,10 @@ gitrevision.bat
 **/*.p12
 **/*.rej
 **/*.orig
+
+########################################
+#             cmake                    #
+########################################
+# build directory naming convention
+build/
+LastVersion.txt

--- a/cmake/modules/FindQScintilla.cmake
+++ b/cmake/modules/FindQScintilla.cmake
@@ -84,7 +84,7 @@ IF(Qt5Widgets_FOUND)
     SET(LIBRARYPATH ${QT5_WIDGETSLIBRARYPATH} "/usr/lib/" "/usr/local/lib")
     MESSAGE("QScintilla2 LIBPATH \"${LIBRARYPATH}\"")
 
-    FIND_LIBRARY(QSCINTILLA_LIBRARY NAMES qscintilla2-qt5 qt5scintilla2 libqscintilla2.so libqscintilla2.a qscintilla2.lib PATHS ${LIBRARYPATH})
+    FIND_LIBRARY(QSCINTILLA_LIBRARY NAMES qscintilla2-qt5 qt5scintilla2 libqscintilla2_qt5.so libqscintilla2.so libqscintilla2.a qscintilla2.lib PATHS ${LIBRARYPATH})
 
     # Check
     IF(QSCINTILLA_LIBRARY)


### PR DESCRIPTION
On both Ubuntu and Arch, the library name is libqscintilla2_qt5.so, and not libqscintilla2-qt5.so. So, added that in findQscintilla.cmake