### PR TITLE
Fix the compilation error - issue #116

### DIFF
--- a/src/widgets/toaboutcopying.cpp
+++ b/src/widgets/toaboutcopying.cpp
@@ -35,6 +35,8 @@
 #include "widgets/toaboutcopying.h"
 
 #include <QtCore/QFile>
+#include <QtCore/QFileInfo>
+#include <QtCore/QDir>
 
 toAboutCopying::toAboutCopying(QWidget* parent, const char* name)
     : QWidget(parent)


### PR DESCRIPTION
Adding 2 missing headers in toaboutcopying.cpp to avoid compilation errors:
 - QtCore/QFileInfo
 - QtCore/QDir