### PR TITLE
Add missing includes - fix compillation issues with Qt 5.14

### DIFF
--- a/src/core/totablemodel.cpp
+++ b/src/core/totablemodel.cpp
@@ -71,13 +71,13 @@ QVariant toTableModelPriv::data(QModelIndex const& index, int role) const
 {
     if (!index.isValid())
     {
-        goto INVALID;
+	throw QString("Invalid index row: %1").arg(index.row());
         return QVariant();
     }
 
     if (index.row() >= Rows.size()) //
     {
-        goto INVALID;
+	throw QString("Invalid index row: %1").arg(index.row());
         return QVariant();
     }
 
@@ -131,7 +131,6 @@ QVariant toTableModelPriv::data(QModelIndex const& index, int role) const
             return QVariant();
     }
 
-INVALID:
     throw QString("Invalid index row: %1").arg(index.row());
     return QVariant();
 }

--- a/src/tools/toresulttableview.cpp
+++ b/src/tools/toresulttableview.cpp
@@ -54,6 +54,7 @@
 #include <QtCore/QTimer>
 #include <QtCore/QtDebug>
 #include <QtCore/QMimeData>
+#include <QFontDatabase>
 #include <QtGui/QClipboard>
 #include <QtGui/QFont>
 #include <QtGui/QFontMetrics>

--- a/src/widgets/totableview.cpp
+++ b/src/widgets/totableview.cpp
@@ -38,7 +38,10 @@
 #include "core/tolistviewformatter.h"
 #include "core/tolistviewformatteridentifier.h"
 
+#include <QApplication>
+#include <QClipboard>
 #include <QHeaderView>
+#include <QMenu>
 #include <QContextMenuEvent>
 
 using namespace Views;

--- a/src/widgets/totableview.h
+++ b/src/widgets/totableview.h
@@ -38,6 +38,7 @@
 
 #include <QTableView>
 #include <QFont>
+#include <QHeaderView>
 
 class QAbstractItemModel;
 class QContextMenuEvent;


### PR DESCRIPTION
These includes I have to add to make Tora compile with latest Qt libs. Also, I had to remove goto command - I'm not sure why was gcc unhappy with this.

This probably will fix issue #141